### PR TITLE
Fix variable name in PC regression script

### DIFF
--- a/blog/2018-09-26_pc_regression.R
+++ b/blog/2018-09-26_pc_regression.R
@@ -31,10 +31,10 @@ pcr.fit = pcr(Salary ~ ., data = Hitters, subset = train,
 validationplot(pcr.fit, val.type = "MSEP")
 
 
-cverr <- MSEP(pcrfit)$val[2,,]
+cverr <- MSEP(pcr.fit)$val[2,,]
 imin <- which.min(cverr)
 if (imin > 1) {
-    predictions <- c(predict(pcrfit, data.frame(X_test_mat), ncomp = imin - 1))
+    predictions <- c(predict(pcr.fit, data.frame(X_test_mat), ncomp = imin - 1))
     MSE_mat[i, 2 + length(rat) + 3] <- MSE(predictions, signal_test)
     support_mat[i, 2 + length(rat) + 3] <- p
 } else {


### PR DESCRIPTION
## Summary
- correct variable name in `blog/2018-09-26_pc_regression.R`

## Testing
- *No tests available for this repo*

------
https://chatgpt.com/codex/tasks/task_e_685b08ff03f88333b2cd44c0687d5b3c